### PR TITLE
[Trivial] Fix Discord Link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,6 @@ There are a few other hardware components that are needed for a complete bitaxe.
 
 ## More Information
 - Project page at [bitaxe.org](https://bitaxe.org)
-- [Open Source Miners United](discord.gg/osmu) Discord chat
+- [Open Source Miners United](https://discord.com/invite/osmu) Discord chat
 - [building.md](building.md) for PCB ordering tips
 - [assembly.md](assembly.md) for assembly tips


### PR DESCRIPTION
Link works when typing in browser, but broken when I tried to join with the error message below.
<img width="1710" height="619" alt="image" src="https://github.com/user-attachments/assets/054ddeb7-150d-4ecb-a027-b8ea5ca96126" />
